### PR TITLE
fix rss icon link error

### DIFF
--- a/_includes/icons.html
+++ b/_includes/icons.html
@@ -2,7 +2,7 @@
 
 {% if icons.rss %}
 <li>
-    <a href="{{ '/feed.xml' | prepend: site.baseurl | prepend: site.url }}">
+    <a href="{{ '/feed.xml' | prepend: site.baseurl }}">
         <i class="fa fa-fw fa-rss"></i>
     </a>
 </li>


### PR DESCRIPTION
The RSS icon link can not be prepended site.url，because site.url mostly is "http://localhost:4000/XXX" for testing, it's better to not prepend site.url
