### PR TITLE
revert integration of site.url and site.baseurl

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,9 +1,10 @@
 #
 # Basic settings.
 #
-#baseurl: http://localhost:4000
-#baseurl: http://qckanemoto.github.io
-baseurl: http://qckanemoto.github.io/jekyll-qck-theme
+# url: http://localhost:4000
+# baseurl: ""
+url: http://qckanemoto.github.io
+baseurl: /jekyll-qck-theme
 title: Your name
 description: Some descriptions of yourself.
 avatar: /assets/img/ogp.png

--- a/_includes/page-url-resolver.html
+++ b/_includes/page-url-resolver.html
@@ -1,7 +1,7 @@
 {% assign page = include.page %}
 
 {% if page.canonical %}
-{% assign url = page.canonical | prepend: site.baseurl %}
+{% assign url = page.canonical | prepend: site.baseurl | prepend: site.url %}
 {% else %}
-{% assign url = page.url | replace: 'index.html', '' | prepend: site.baseurl %}
+{% assign url = page.url | replace: 'index.html', '' | prepend: site.baseurl | prepend: site.url %}
 {% endif %}

--- a/feed.xml
+++ b/feed.xml
@@ -6,8 +6,8 @@ layout: null
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>{{ site.title | xml_escape }}</title>
-    <atom:link href="{{ '/feed.xml' | prepend: site.baseurl }}" rel="self" type="application/rss+xml"/>
-    <link>{{ site.baseurl }}/</link>
+    <atom:link href="{{ '/feed.xml' | prepend: site.baseurl | prepend: site.url }}" rel="self" type="application/rss+xml"/>
+    <link>{{ site.baseurl | prepend: site.url }}/</link>
     <description>{{ site.description | xml_escape }}</description>
     <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
     {% for post in site.posts limit:15 %}


### PR DESCRIPTION
#12 was not a good idea... :sweat:

it caused the same problem as https://github.com/jekyll/jekyll/issues/2317.
so this PR fix this with re-separating site.url and site.baseurl.
