### PR TITLE
show recent posts on newest jekyll version

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -91,7 +91,13 @@
             <div class="block sticky">
                 <h1>{{ site.str_recent_posts }}</h1>
                 <ul>
-                    {% assign posts = (site.posts | where: 'hide', null | sort: 'date' | reverse) %}
+                    {% assign posts = '' | split: '' %}
+                    {% for post in site.posts %}
+                    {% if post.hide != true %}
+                    {% assign posts = posts | push: post %}
+                    {% endif %}
+                    {% endfor %}
+                    {% assign posts = posts | sort: 'date' | reverse %}
                     {% for post in posts limit:site.recent_posts_num %}
                     <li><a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a></li>
                     {% endfor %}


### PR DESCRIPTION
On Jekyll of newest version, the posts with no `hide` attribution were not shown on "Recent Posts" area. This PR fix this problem.

| Before | After |
| --- | --- |
| ![image](https://cloud.githubusercontent.com/assets/4360663/18774782/887c548c-8197-11e6-8186-99eeb76b2338.png) | ![image](https://cloud.githubusercontent.com/assets/4360663/18774785/94a972da-8197-11e6-952d-e31de8ce7de9.png) |
