### PR TITLE
[bug fix] show posts in feed.xml

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -10,7 +10,12 @@ layout: null
     <link>{{ site.baseurl | prepend: site.url }}/</link>
     <description>{{ site.description | xml_escape }}</description>
     <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
-    {% assign posts = site.posts | where: 'hide', null %}
+    {% assign posts = '' | split: '' %}
+    {% for post in site.posts %}
+    {% if post.hide != true %}
+    {% assign posts = posts | push: post %}
+    {% endif %}
+    {% endfor %}
     {% for post in posts limit:15 %}
       {% include page-url-resolver.html page=post %}
       <item>


### PR DESCRIPTION
On Jekyll of newest version, the posts with no hide attribution were not shown in feed.xml. This PR fix this problem.

see also #24 🙇 

| Before | After |
| --- | --- |
| ![image](https://cloud.githubusercontent.com/assets/4360663/19202756/d63ef5f8-8d0e-11e6-9127-d510b313a4c5.png) | ![image](https://cloud.githubusercontent.com/assets/4360663/19202765/e196b06c-8d0e-11e6-89b8-5c5f6338a2fb.png) |
